### PR TITLE
Upgrade to .NET 4.7.1 and Matomo terminology

### DIFF
--- a/Piwik.Tracker.Samples/Piwik.Tracker.Samples.csproj
+++ b/Piwik.Tracker.Samples/Piwik.Tracker.Samples.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Piwik.Tracker.Samples</RootNamespace>
     <AssemblyName>Piwik.Tracker.Samples</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/Piwik.Tracker.Samples/PiwikTrackerSamples.cs
+++ b/Piwik.Tracker.Samples/PiwikTrackerSamples.cs
@@ -10,7 +10,7 @@ namespace Piwik.Tracker.Samples
     internal class PiwikTrackerSamples
     {
         private const string UA = "Firefox";
-        private static readonly string PiwikBaseUrl = "http://piwik.local";
+        private static readonly string PiwikBaseUrl = "http://matomo.local";
         private static readonly int SiteId = 1;
 
         private static void Main(string[] args)

--- a/Piwik.Tracker.Tests/Piwik.Tracker.Tests.csproj
+++ b/Piwik.Tracker.Tests/Piwik.Tracker.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Piwik.Tracker.Tests</RootNamespace>
     <AssemblyName>Piwik.Tracker.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
@@ -33,20 +33,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+    <Reference Include="Microsoft.Owin, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.2.2\lib\net461\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.4.2.2\lib\net461\Microsoft.Owin.Host.HttpListener.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Hosting, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.4.2.2\lib\net461\Microsoft.Owin.Hosting.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.13.3\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
@@ -61,8 +61,8 @@
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.9\lib\net461\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
@@ -70,11 +70,11 @@
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    <Reference Include="System.Web.Http, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.9\lib\net461\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.Owin, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
+    <Reference Include="System.Web.Http.Owin, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Owin.5.2.9\lib\net461\System.Web.Http.Owin.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Piwik.Tracker.Tests/PiwikTrackerTests.cs
+++ b/Piwik.Tracker.Tests/PiwikTrackerTests.cs
@@ -15,7 +15,7 @@ namespace Piwik.Tracker.Tests
     internal class PiwikTrackerTests
     {
         private const string UA = "Firefox";
-        private const string PiwikBaseUrl = "http://piwik.local";
+        private const string PiwikBaseUrl = "http://matomo.local";
         private const int SiteId = 1;
         private PiwikTracker _sut;
 

--- a/Piwik.Tracker.Tests/PiwikTrackerWithMockedServerTests.cs
+++ b/Piwik.Tracker.Tests/PiwikTrackerWithMockedServerTests.cs
@@ -19,7 +19,7 @@ namespace Piwik.Tracker.Tests
         private PiwikTracker _sut;
         private MockedHttpServer _mockedPiwikServer;
         private const string UA = "Firefox";
-        private const string PiwikBaseUrl = "http://127.0.0.1:1122/piwik.php";
+        private const string PiwikBaseUrl = "http://127.0.0.1:1122/matomo.php";
         private const int SiteId = 1;
 
         private static readonly NameValueCollection DefaultRequestParameter = new NameValueCollection

--- a/Piwik.Tracker.Tests/packages.config
+++ b/Piwik.Tracker.Tests/packages.config
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net461" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net461" />
-  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net461" />
-  <package id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.3" targetFramework="net461" />
-  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />
-  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net461" />
-  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net461" />
-  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net461" />
-  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net461" />
-  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="NUnit" version="3.6.0" targetFramework="net45" />
-  <package id="Owin" version="1.0" targetFramework="net461" />
-  <package id="SimpleHttpMock" version="1.1.5" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.9" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.9" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.9" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.9" targetFramework="net471" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net471" />
+  <package id="Microsoft.Owin" version="4.2.2" targetFramework="net471" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="4.2.2" targetFramework="net471" />
+  <package id="Microsoft.Owin.Hosting" version="4.2.2" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net471" />
+  <package id="NUnit" version="3.13.3" targetFramework="net471" />
+  <package id="Owin" version="1.0" targetFramework="net471" />
+  <package id="SimpleHttpMock" version="1.1.5" targetFramework="net471" />
 </packages>

--- a/Piwik.Tracker.Web.Samples/Piwik.Tracker.Web.Samples.csproj
+++ b/Piwik.Tracker.Web.Samples/Piwik.Tracker.Web.Samples.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Piwik</RootNamespace>
     <AssemblyName>WebTrackerTest</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Piwik.Tracker.Web.Samples/Web.config
+++ b/Piwik.Tracker.Web.Samples/Web.config
@@ -5,7 +5,7 @@
     </system.web>
 
     <appSettings>
-        <add key="PiwikURL" value="http://piwik" />
+        <add key="PiwikURL" value="http://matomo" />
         <add key="SiteId" value="1" />
     </appSettings>
 </configuration>

--- a/Piwik.Tracker/CustomVar.cs
+++ b/Piwik.Tracker/CustomVar.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// Visit Custom Variable
-    /// See http://piwik.org/docs/custom-variables/
+    /// See https://matomo.org/docs/custom-variables/
     /// </summary>
     public class CustomVar
     {

--- a/Piwik.Tracker/Piwik.Tracker.csproj
+++ b/Piwik.Tracker/Piwik.Tracker.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Piwik.Tracker</RootNamespace>
     <AssemblyName>Piwik.Tracker</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Piwik.Tracker/Piwik.Tracker.nuspec
+++ b/Piwik.Tracker/Piwik.Tracker.nuspec
@@ -4,13 +4,13 @@
     <id>$id$</id>
     <version>$version$</version>
     <authors>$author$</authors>
-    <summary>.NET Client for Piwik Analytics Tracking API</summary>
-    <description>The C# Tracker Client provides all features of the Piwik Javascript Tracker, such as Ecommerce Tracking, Custom Variable, Event tracking and more.</description>
+    <summary>.NET Client for Matomo (Piwik) Analytics Tracking API</summary>
+    <description>The C# Tracker Client provides all features of the Matomo (formerly Piwik) Javascript Tracker, such as Ecommerce Tracking, Custom Variable, Event tracking and more.</description>
     <language>en-US</language>
     <projectUrl>https://github.com/piwik/piwik-dotnet-tracker</projectUrl>
     <licenseUrl>https://raw.githubusercontent.com/piwik/piwik-dotnet-tracker/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.githubusercontent.com/piwik/piwik-dotnet-tracker/master/logo.png</iconUrl>
-    <tags>piwik analytics tracking</tags>
+    <tags>matomo piwik analytics tracking</tags>
   </metadata>
 </package>

--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -1,12 +1,12 @@
 ﻿// <summary>
-// Piwik - free/libre analytics platform
+// Matomo - free/libre analytics platform
 //
-// Client to record visits, page views, Goals, Ecommerce activity (product views, add to carts, Ecommerce orders) in a Piwik server.
-// This is a C# Version of the piwik.js standard Tracking API.
-// For more information, see http://piwik.org/docs/tracking-api/
+// Client to record visits, page views, Goals, Ecommerce activity (product views, add to carts, Ecommerce orders) in a Matomo server.
+// This is a C# Version of the Matomo (formerly Piwik) standard Tracking API.
+// For more information, see https://matomo.org/docs/tracking-api/
 //
-// <see href="http://piwik.org/docs/tracking-api/"/>
-// Piwik Server Api: <see href="http://developer.piwik.org/api-reference/tracking-api"/>
+// <see href="https://matomo.org/docs/tracking-api/"/>
+// Matomo Server Api: <see href="https://developer.matomo.org/api-reference/tracking-api"/>
 // </summary>
 
 namespace Piwik.Tracker
@@ -22,18 +22,18 @@ namespace Piwik.Tracker
     using System.Text.RegularExpressions;
 
     /// <summary>
-    /// PiwikTracker implements the Piwik Tracking Web API.
+    /// PiwikTracker implements the Matomo (Piwik) Tracking Web API.
     ///
     /// The PHP Tracking Client provides all features of the Javascript Tracker, such as Ecommerce Tracking, Custom Variable, Event tracking and more.
     /// Functions are named the same as the Javascript functions.
     ///
-    /// See introduction docs at: {@link http://piwik.org/docs/tracking-api/}
+    /// See introduction docs at: {@link https://matomo.org/docs/tracking-api/}
     ///
-    /// ### Example: using the PHP PiwikTracker class
+    /// ### Example: using the PHP MatomoTracker class
     ///
     /// The following code snippet is an advanced example of how to track a Page View using the Tracking API PHP client.
     ///
-    ///      $t = new PiwikTracker( $idSite = 1, 'http://example.org/piwik/');
+    ///      $t = new PiwikTracker( $idSite = 1, 'http://example.org/matomo/');
     ///
     ///      // Optional function calls
     ///      $t->setUserAgent( "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB) Firefox/3.6.6");
@@ -68,9 +68,9 @@ namespace Piwik.Tracker
     /// Usually, Ecommerce tracking is done using standard Javascript code,
     /// but it is very common to record Ecommerce interactions after the fact
     /// (for example, when payment is done with Paypal and user doesn't come back on the website after purchase).
-    /// For more information about Ecommerce tracking in Piwik, check out the documentation: Tracking Ecommerce in Piwik.
+    /// For more information about Ecommerce tracking in Matomo, check out the documentation: Tracking Ecommerce in Matomo.
     ///
-    ///      $t = new PiwikTracker( $idSite = 1, 'http://example.org/piwik/');
+    ///      $t = new PiwikTracker( $idSite = 1, 'http://example.org/matomo/');
     ///
     ///      // Force IP to the actual visitor IP
     ///      $t->setTokenAuth( $token_auth );
@@ -117,7 +117,7 @@ namespace Piwik.Tracker
 	    private const string DefaultCharsetParameterValues = "utf-8";
 
         /// <summary>
-        /// <see cref="http://developer.piwik.org/api-reference/tracking-javascript"/>
+        /// <see cref="https://developer.matomo.org/api-reference/tracking-javascript"/>
         /// </summary>
         private const string FirstPartyCookiesPrefix = "_pk_";
 
@@ -185,18 +185,18 @@ namespace Piwik.Tracker
 
         /// <summary>
         /// Builds a PiwikTracker object, used to track visits, pages and Goal conversions
-        /// for a specific website, by using the Piwik Tracking API.
+        /// for a specific website, by using the Matomo Tracking API.
         /// If the tracker is used within a web page or web controller, the following information are pre-initialised :
         /// URL Referrer, current page URL, remote IP, Accept-Language HTTP header and User-Agent HTTP header.
         /// </summary>
         /// <param name="idSite">Id site to be tracked</param>
-        /// <param name="apiUrl">"http://example.org/piwik/" or "http://piwik.example.org/". If set, will overwrite PiwikTracker.URL</param>
+        /// <param name="apiUrl">"http://example.org/matomo/" or "http://matomo.example.org/". If set, will overwrite PiwikTracker.URL</param>
         /// <exception cref="ArgumentException">apiUrl must not be null or empty</exception>
         public PiwikTracker(int idSite, string apiUrl)
         {
             if (string.IsNullOrEmpty(apiUrl))
             {
-                throw new ArgumentException("Piwik api url must not be emty or null.", nameof(apiUrl));
+                throw new ArgumentException("Matomo api url must not be empty or null.", nameof(apiUrl));
             }
             PiwikBaseUrl = FixPiwikBaseUrl(apiUrl);
             IdSite = idSite;
@@ -213,13 +213,13 @@ namespace Piwik.Tracker
         }
 
         /// <summary>
-        /// Gets the Piwik base URL, for example http://example.org/piwik/
+        /// Gets the Matomo base URL, for example http://example.org/matomo/
         /// </summary>
         public string PiwikBaseUrl { get; }
 
         /// <summary>
-        /// Gets the piwik site ID.
-        /// see: http://developer.piwik.org/api-reference/tracking-api
+        /// Gets the Matomo site ID.
+        /// see: https://developer.matomo.org/api-reference/tracking-api
         /// idsite (required) — The ID of the website we're tracking a visit/action for.
         /// </summary>
         public int IdSite { get; }
@@ -282,7 +282,7 @@ namespace Piwik.Tracker
         /// to the 'ref' first party cookie storing referral information.
         /// </summary>
         /// <param name="attributionInfo">Attribution info for the visit</param>
-        /// <see>function getAttributionInfo() in "https://github.com/piwik/piwik/blob/master/js/piwik.js"</see>
+        /// <see>function getAttributionInfo() in "https://github.com/matomo-org/matomo/blob/master/js/piwik.js"</see>
         public void SetAttributionInfo(AttributionInfo attributionInfo)
         {
             _attributionInfo = attributionInfo;
@@ -290,7 +290,7 @@ namespace Piwik.Tracker
 
         /// <summary>
         /// Sets Visit Custom Variable.
-        /// See http://piwik.org/docs/custom-variables/
+        /// See https://matomo.org/docs/custom-variables/
         /// </summary>
         /// <param name="id">Custom variable slot ID from 1-5</param>
         /// <param name="name">Custom variable name</param>
@@ -566,7 +566,7 @@ namespace Piwik.Tracker
         /// <returns></returns>
         protected string GetCookieName(string cookieName)
         {
-            // NOTE: If the cookie name is changed, we must also update the method in piwik.js with the same name.
+            // NOTE: If the cookie name is changed, we must also update the method in matomo.js/piwik.js with the same name.
             var cookieDomain = (string.IsNullOrWhiteSpace(_configCookieDomain)
                 ? GetCurrentHost()
                 : _configCookieDomain)
@@ -912,7 +912,7 @@ namespace Piwik.Tracker
         /// </summary>
         /// <see cref="DoTrackPageView"/>
         /// <param name="documentTitle">Page view name as it will appear in Piwik reports</param>
-        /// <returns>URL to piwik.php with all parameters set to track the pageview</returns>
+        /// <returns>URL to matomo.php with all parameters set to track the pageview</returns>
         public string GetUrlTrackPageView(string documentTitle = "")
         {
             var url = GetRequest(IdSite);
@@ -933,7 +933,7 @@ namespace Piwik.Tracker
         /// <param name="name">(optional) The Event's object Name (a particular Movie name, or Song name, or File name...)</param>
         /// <param name="value">(optional) The Event's value</param>
         /// <returns>
-        /// URL to piwik.php with all parameters set to track the pageview
+        /// URL to matomo.php with all parameters set to track the pageview
         /// </returns>
         /// <exception cref="ArgumentException">
         /// You must specify an Event Category name (Music, Videos, Games...). - category
@@ -974,7 +974,7 @@ namespace Piwik.Tracker
         /// <param name="contentPiece">The actual content. For instance the path to an image, video, audio, any text</param>
         /// <param name="contentTarget">(optional) The target of the content. For instance the URL of a landing page.</param>
         /// <returns>
-        /// URL to piwik.php with all parameters set to track the pageview
+        /// URL to matomo.php with all parameters set to track the pageview
         /// </returns>
         /// <exception cref="ArgumentException">You must specify a content name - contentName</exception>
         /// <see cref="DoTrackContentImpression" />
@@ -1008,7 +1008,7 @@ namespace Piwik.Tracker
         /// <param name="contentPiece">The actual content. For instance the path to an image, video, audio, any text</param>
         /// <param name="contentTarget">(optional) The target the content leading to when an interaction occurs. For instance the URL of a landing page.</param>
         /// <returns>
-        /// URL to piwik.php with all parameters set to track the pageview
+        /// URL to matomo.php with all parameters set to track the pageview
         /// </returns>
         /// <exception cref="ArgumentException">
         /// You must specify a name for the interaction - interaction
@@ -1073,7 +1073,7 @@ namespace Piwik.Tracker
         /// <see cref="DoTrackGoal"/>
         /// <param name="idGoal">Id Goal to record a conversion</param>
         /// <param name="revenue">Revenue for this conversion</param>
-        /// <returns>URL to piwik.php with all parameters set to track the goal conversion</returns>
+        /// <returns>URL to matomo.php with all parameters set to track the goal conversion</returns>
         public string GetUrlTrackGoal(int idGoal, float revenue = 0)
         {
             var url = GetRequest(IdSite);
@@ -1091,7 +1091,7 @@ namespace Piwik.Tracker
         /// <see cref="DoTrackAction"/>
         /// <param name="actionUrl">URL of the download or outlink</param>
         /// <param name="actionType">Type of the action: 'download' or 'link'</param>
-        /// <returns>URL to piwik.php with all parameters set to track an action</returns>
+        /// <returns>URL to matomo.php with all parameters set to track an action</returns>
         public string GetUrlTrackAction(string actionUrl, ActionType actionType)
         {
             var url = GetRequest(IdSite);
@@ -1447,16 +1447,15 @@ namespace Piwik.Tracker
         }
 
         /// <summary>
-        /// Returns the base URL for the piwik server.
+        /// Returns the base URL for the Matomo server.
         /// </summary>
         /// <param name="url">The URL.</param>
         /// <returns></returns>
         private static string FixPiwikBaseUrl(string url)
         {
-            if (!url.Contains("/piwik.php") && !url.Contains("/proxy-piwik.php")
-            )
+            if (!url.Contains("/piwik.php") && !url.Contains("/matomo.php") && !url.Contains("/proxy-piwik.php"))
             {
-                url += "/piwik.php";
+                url += "/matomo.php";
             }
             return url;
         }
@@ -1468,7 +1467,7 @@ namespace Piwik.Tracker
             var customFields = _customParameters.Aggregate("",
                 (current, kvp) => current + $"&{UrlEncode(kvp.Key)}={UrlEncode(kvp.Value)}"
             );
-            // http://developer.piwik.org/api-reference/tracking-api
+            // https://developer.matomo.org/api-reference/tracking-api
             // Required parameters:
             //     idsite(required) — The ID of the website we're tracking a visit/action for.
             //     rec(required) — Required for tracking, must be set to one, eg, &rec = 1.
@@ -1635,7 +1634,7 @@ namespace Piwik.Tracker
         }
 
         /// <summary>
-        /// Sets the first party cookies as would the piwik.js
+        /// Sets the first party cookies as would the Matomo JavaScript tracker
         /// All cookies are supported: 'id' and 'ses' and 'ref' and 'cvar' cookies.
         /// </summary>
         protected void SetFirstPartyCookies()
@@ -1670,7 +1669,7 @@ namespace Piwik.Tracker
 
         /// <summary>
         /// Sets a first party cookie to the client to improve dual JS-PHP tracking.
-        /// This replicates the piwik.js tracker algorithms for consistency and better accuracy.
+        /// This replicates the Matomo JavaScript tracker algorithms for consistency and better accuracy.
         /// </summary>
         /// <param name="cookieName">Name of the cookie.</param>
         /// <param name="cookieValue">The cookie value.</param>

--- a/Piwik.Tracker/TrackingResponse.cs
+++ b/Piwik.Tracker/TrackingResponse.cs
@@ -8,7 +8,7 @@ namespace Piwik.Tracker
     public class TrackingResponse
     {
         /// <summary>
-        /// Gets the HTTP status code recived from the piwik server.
+        /// Gets the HTTP status code received from the Matomo server.
         /// </summary>
         public HttpStatusCode HttpStatusCode { get; internal set; }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Piwik C# Tracking API [![Build Status](https://travis-ci.org/piwik/piwik-dotnet-tracker.svg?branch=master)](https://travis-ci.org/piwik/piwik-dotnet-tracker) [![NuGet](https://img.shields.io/nuget/dt/Piwik.Tracker.svg)](https://www.nuget.org/packages/Piwik.Tracker/)
+# Matomo C# Tracking API [![Build Status](https://travis-ci.org/piwik/piwik-dotnet-tracker.svg?branch=master)](https://travis-ci.org/piwik/piwik-dotnet-tracker) [![NuGet](https://img.shields.io/nuget/dt/Piwik.Tracker.svg)](https://www.nuget.org/packages/Piwik.Tracker/)
 
-This is the official C# implementation of the [Piwik Tracking API](http://piwik.org/docs/tracking-api/).
+This is the official C# implementation of the [Matomo Tracking API](https://matomo.org/docs/tracking-api/). The library was previously known as **Piwik Tracker**.
 
  - [Changelog](CHANGELOG.md)
  - [Contributor doc](CONTRIBUTE.md)


### PR DESCRIPTION
## Summary
- target .NET Framework 4.7.1 for all projects
- refresh Matomo references and default URLs
- modernize nuspec metadata
- update test packages

## Testing
- `dotnet` not available, unable to run tests